### PR TITLE
Fix broken tests and add missing requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 pytest
 flake8
+python-dateutil
+pulp

--- a/slotmachine/__init__.py
+++ b/slotmachine/__init__.py
@@ -12,6 +12,8 @@ class Unsatisfiable(Exception):
 
 class SlotMachine(object):
     Talk = namedtuple("Talk", ("id", "duration", "venues", "speakers", "preferred_venues", "preferred_slots"))
+    # If preferred venues and/or slots are not specified, assume there are no preferences
+    Talk.__new__.__defaults__ = ([], [])
 
     def __init__(self):
         self.log = logging.getLogger(__name__)


### PR DESCRIPTION
Tests are currently failing. This is due to the test harness assuming that the `Talk` `namedtuple` will assume that there are no slot or venue preferences if the parameters are not set.

This PR resolves the broken tests by setting default values. It is compatible with Python 3.6 and later.

There were also several packages missing from requirements.txt. With these now added, Slotmachine will work in a venv.