### PR TITLE
Refactor library interface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ build-backend = "uv_build"
 
 [dependency-groups]
 dev = [
+    "hypothesis>=6.152.7",
     "mypy>=1.17.1",
     "pytest>=8.4.1",
     "pytest-github-actions-annotate-failures>=0.3.0",

--- a/src/slotmachine/__init__.py
+++ b/src/slotmachine/__init__.py
@@ -1,4 +1,10 @@
-from .data import Talk
+from .data import SchedulingProblem, SchedulingSolution, Talk
 from .slotmachine import SlotMachine, Unsatisfiable
 
-__all__ = ["SlotMachine", "Talk", "Unsatisfiable"]
+__all__ = [
+    "SchedulingProblem",
+    "SchedulingSolution",
+    "SlotMachine",
+    "Talk",
+    "Unsatisfiable",
+]

--- a/src/slotmachine/__main__.py
+++ b/src/slotmachine/__main__.py
@@ -2,8 +2,38 @@ import argparse
 import json
 import logging
 import sys
+from datetime import datetime
+
+from dateutil.parser import parse as parse_datetime
 
 from slotmachine import SlotMachine
+from slotmachine.data import SchedulingProblem, Talk
+
+
+def parse_time_range(range: dict) -> tuple[datetime, datetime]:
+    return (parse_datetime(range["start"]), parse_datetime(range["end"]))
+
+
+def talk_from_json(talk: dict) -> Talk:
+    return Talk(
+        id=talk["id"],
+        duration=talk["duration"],
+        speakers=set(talk["speakers"]),
+        allowed_venues=set(talk["valid_venues"]),
+        preferred_venues=set(talk.get("preferred_venues", [])),
+        allowed_times=[parse_time_range(r) for r in talk["time_ranges"]],
+        preferred_times=[parse_time_range(r) for r in talk.get("preferred_times", [])],
+        minutes_after=10,
+        start_time=parse_datetime(talk.get("time", "")) if talk.get("time") else None,
+        venue=talk.get("venue"),
+    )
+
+
+def problem_from_json(schedule: dict) -> SchedulingProblem:
+    talks = []
+    for talk_data in schedule:
+        talks.append(talk_from_json(talk_data))
+    return SchedulingProblem(talks=talks, slot_duration=10)
 
 
 def main():
@@ -12,19 +42,20 @@ def main():
     ap.add_argument("infile", help="Input file")
     ap.add_argument("outfile", nargs="?", help="Output file (default: stdout)")
     ap.add_argument("-n", "--no-output", action="store_true", help="Suppress output")
+    ap.add_argument("-d", "--debug", action="store_true", help="Show solver debug output")
     args = ap.parse_args()
 
     with open(args.infile) as f:
-        schedule = json.load(f)
+        problem = problem_from_json(json.load(f))
 
-    result = SlotMachine().schedule(schedule)
+    result = SlotMachine(problem).solve(debug=args.debug)
 
     if not args.no_output:
         if args.outfile:
             with open(args.outfile, "w") as f:
-                json.dump(result, f, sort_keys=True, indent=4, separators=(",", ": "))
+                json.dump(result.to_dict(), f, sort_keys=True, indent=4, separators=(",", ": "))
         else:
-            json.dump(result, sys.stdout, sort_keys=True, indent=4, separators=(",", ": "))
+            json.dump(result.to_dict(), sys.stdout, sort_keys=True, indent=4, separators=(",", ": "))
 
 
 if __name__ == "__main__":

--- a/src/slotmachine/data.py
+++ b/src/slotmachine/data.py
@@ -1,8 +1,110 @@
-from collections import namedtuple
+"""Public interface classes for slotmachine."""
 
-Talk = namedtuple(
-    "Talk",
-    ("id", "duration", "venues", "speakers", "slot_intervals", "preferred_venues", "preferred_intervals"),
-)
-# If slot_intervals, preferred venues and/or slots are not specified, assume no restrictions/preferences
-Talk.__new__.__defaults__ = ([], [], [])
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from itertools import chain
+
+type TalkID = int
+type VenueID = int
+type SpeakerID = int
+
+type TimeRange = tuple[datetime, datetime]
+
+
+@dataclass
+class Talk:
+    #: Integer identifier for the talk
+    id: TalkID
+
+    #: Duration of the talk in minutes
+    duration: int
+
+    #: List of speaker IDs who are presenting this talk.
+    #: Talks from the same speaker will be prevented from being scheduled at the same time.
+    speakers: set[SpeakerID]
+
+    #: Venues the talk is allowed to be scheduled in.
+    allowed_venues: set[VenueID]
+    #: Time ranges the talk is allowed to be scheduled in.
+    allowed_times: list[TimeRange]
+
+    #: Preferred venues: can be used to assign more popular talks to larger venues.
+    preferred_venues: set[VenueID] = field(default_factory=set)
+    preferred_times: list[TimeRange] = field(default_factory=list)
+
+    #: Number of minutes allowed after the talk for changeover
+    minutes_after: int = 10
+
+    #: Scheduled start time of the talk - when passed to the scheduler, it will try and
+    #: minimise changes.
+    start_time: datetime | None = None
+    #: Scheduled venue of the talk - when passed to the scheduler, it will try and
+    #: minimise changes.
+    venue: VenueID | None = None
+
+    @property
+    def end_time(self) -> datetime | None:
+        """End time, calculated from the start_time plus the duration"""
+        if self.start_time is None:
+            return None
+        return self.start_time + timedelta(minutes=self.duration)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "duration": self.duration,
+            "speakers": list(self.speakers),
+            "valid_venues": list(self.allowed_venues),
+            "time_ranges": [
+                {"start": tr[0].isoformat(), "end": tr[1].isoformat()} for tr in self.allowed_times
+            ],
+            "preferred_venues": list(self.preferred_venues),
+            "preferred_times": [
+                {"start": tr[0].isoformat(), "end": tr[1].isoformat()} for tr in self.preferred_times
+            ],
+            "minutes_after": self.minutes_after,
+            "time": self.start_time.isoformat() if self.start_time else None,
+            "venue": self.venue,
+        }
+
+
+@dataclass()
+class SchedulingProblem:
+    """A problem for SlotMachine to solve.
+
+    This is an immutable object.
+    """
+
+    talks: list[Talk]
+    slot_duration: int
+
+    start_time: datetime
+    venues: set[VenueID]
+
+    def __init__(self, talks: list[Talk], slot_duration: int):
+        if len(talks) == 0:
+            raise ValueError("No talks provided")
+
+        self.talks = talks
+        self.slot_duration = slot_duration
+
+        self.start_time = min(range[0] for talk in self.talks for range in talk.allowed_times)
+        self.venues = set(chain.from_iterable(talk.allowed_venues for talk in self.talks))
+
+        for talk in self.talks:
+            if talk.duration % self.slot_duration != 0:
+                raise ValueError(
+                    f"Talk {talk.id} duration {talk.duration} is not a multiple of slot duration {self.slot_duration}"
+                )
+            if talk.minutes_after % self.slot_duration != 0:
+                raise ValueError(
+                    f"Talk {talk.id} minutes_after {talk.minutes_after} is not a multiple of slot duration {self.slot_duration}"
+                )
+
+
+@dataclass
+class SchedulingSolution:
+    talks: list[Talk]
+
+    def to_dict(self) -> list[dict]:
+        return [talk.to_dict() for talk in self.talks]

--- a/src/slotmachine/slotmachine.py
+++ b/src/slotmachine/slotmachine.py
@@ -1,16 +1,10 @@
 import logging
 import time
-from collections.abc import Iterable
-from datetime import datetime
 
-from dateutil import parser, relativedelta
 from ortools.sat.python import cp_model
 
-from .data import Talk
-
-type TalkID = int
-type VenueID = int
-type Slot = int
+from .data import SchedulingProblem, SchedulingSolution, SpeakerID, TalkID, VenueID
+from .slots import Slot, SlottedTalk
 
 
 class Unsatisfiable(Exception):
@@ -18,17 +12,16 @@ class Unsatisfiable(Exception):
 
 
 class SlotMachine:
-    def __init__(self) -> None:
+    def __init__(self, problem: SchedulingProblem) -> None:
         self.log = logging.getLogger(__name__)
-        self.talks_by_id: dict[TalkID, Talk] = {}
+        self.problem = problem
 
         # Vars representing the selected talk slot and venue
         self.talk_slot_vars: dict[TalkID, cp_model.IntVar] = {}
         self.talk_venue_active_vars: dict[tuple[TalkID, VenueID], cp_model.IntVar] = {}
 
-    def get_problem(self, venues, talks: list[Talk], old_talks) -> cp_model.CpModel:
+    def generate_problem(self, venues, talks: list[SlottedTalk]) -> None:
         self.model = cp_model.CpModel()
-        self.talks_by_id = {talk.id: talk for talk in talks}
         self.talk_slot_vars = {}
         self.talk_venue_active_vars = {}
 
@@ -44,24 +37,21 @@ class SlotMachine:
         # existing schedule, or optimise the schedule in any way.
 
         for talk in talks:
-            duration = talk.duration
-            allowed_venues = [v for v in venues if v in talk.venues]
-
             # Calculate start slots that a talk can actually be in, filtering
             # intervals to remove any that are too small
             allowed_intervals = [
-                [int_start, int_end - duration + 1]
-                for int_start, int_end in talk.slot_intervals
-                if int_end - int_start + 1 >= duration
+                [int_start, int_end - talk.duration + 1]
+                for int_start, int_end in talk.allowed_intervals
+                if int_end - int_start + 1 >= talk.duration
             ]
 
-            # If we dont't have any intervals, or any intervals large enough to
+            # If we don't have any intervals, or any intervals large enough to
             # fit this talk, or no venues specified exist, create a variable
             # that cannot possibly be satisfied for warning purposes. We do
             # this because otherwise the valid talk domain or venues would end
             # up being empty and instead of failing to solve the talk would
             # just be ignored.
-            if not allowed_intervals or not allowed_venues:
+            if not allowed_intervals or not talk.allowed_venues:
                 oh_no_var = self.model.new_bool_var(f"_impossible_{talk.id}")
                 self.model.add(oh_no_var == 1)
                 self.model.add(oh_no_var == 0)
@@ -69,7 +59,7 @@ class SlotMachine:
 
             # The highest slot a talk can occupy, used later for setting
             # variable search bounds
-            talk_slot_max[talk.id] = allowed_intervals[-1][1]
+            talk_slot_max[talk.id] = max(interval[1] for interval in allowed_intervals)
 
             # Int var representing the possible talk slots inside the set of
             # permitted intervals for this talk
@@ -82,7 +72,7 @@ class SlotMachine:
             # Interval var representing the talk period without venue, used to
             # prevent speakers being in multiple places at the same time
             talk_intervals[talk.id] = self.model.new_interval_var(
-                start_var, duration, start_var + duration, f"talk_interval_{talk.id}"
+                start_var, talk.duration, start_var + talk.duration, f"talk_interval_{talk.id}"
             )
 
             # A set of optional Interval vars that represent all possible
@@ -90,15 +80,19 @@ class SlotMachine:
             # only one will be chosen (enforced by the followup constraint).
             # The active bool var will be true for the slot that is selected.
             venue_active_vars: list[cp_model.IntVar] = []
-            for v in allowed_venues:
-                active = self.model.new_bool_var(f"talk_venue_active_{talk.id}_{v}")
-                self.talk_venue_active_vars[(talk.id, v)] = active
+            for venue in talk.allowed_venues:
+                active = self.model.new_bool_var(f"talk_venue_active_{talk.id}_{venue}")
+                self.talk_venue_active_vars[(talk.id, venue)] = active
                 venue_active_vars.append(active)
 
                 optional_talk_venue_interval = self.model.new_optional_interval_var(
-                    start_var, duration, start_var + duration, active, f"talk_venue_interval_{talk.id}_{v}"
+                    start_var,
+                    talk.duration,
+                    start_var + talk.duration,
+                    active,
+                    f"talk_venue_interval_{talk.id}_{venue}",
                 )
-                venue_intervals.setdefault(v, []).append(optional_talk_venue_interval)
+                venue_intervals.setdefault(venue, []).append(optional_talk_venue_interval)
 
             # Exactly one venue must be chosen for a talk
             self.model.add(cp_model.LinearExpr.sum(venue_active_vars) == 1)
@@ -109,7 +103,7 @@ class SlotMachine:
                 self.model.add_no_overlap(intervals)
 
         # And a speaker cannot give multiple talks simultaneously
-        talks_by_speaker: dict[str, list[TalkID]] = {}
+        talks_by_speaker: dict[SpeakerID, list[TalkID]] = {}
         for talk in talks:
             # Ensure we've not filtered the talk for being impossible
             if talk.id in talk_intervals:
@@ -133,9 +127,9 @@ class SlotMachine:
         # Maximise the number of things in their preferred venues (for putting
         # big talks on big stages)
         for talk in talks:
-            for v in talk.preferred_venues:
-                if (talk.id, v) in self.talk_venue_active_vars:
-                    obj_vars.append(self.talk_venue_active_vars[(talk.id, v)])
+            for venue in talk.preferred_venues:
+                if (talk.id, venue) in self.talk_venue_active_vars:
+                    obj_vars.append(self.talk_venue_active_vars[(talk.id, venue)])
                     obj_scores.append(5 * talk.duration)
 
         # Maximise the number of things in their preferred slots. This is
@@ -177,12 +171,15 @@ class SlotMachine:
         # Maximise the number of things staying in the same slot and venue, as
         # we always want to make the minimal changes to the schedule when
         # altering talk constraints
-        for old_slot, talk_id, old_venue in old_talks:
-            if talk_id not in self.talk_slot_vars:
+        for talk in talks:
+            # We're only considering talks with an existing scheduled time
+            if not talk.start or not talk.venue:
                 continue
 
-            start = self.talk_slot_vars[talk_id]
-            duration = self.talks_by_id[talk_id].duration
+            if talk.id not in self.talk_slot_vars:
+                continue
+
+            start = self.talk_slot_vars[talk.id]
 
             # Attempt to keep talks in the same slot, or within a two-hour
             # window of the current slot. The cost of the slot move grows
@@ -191,40 +188,36 @@ class SlotMachine:
             # move them anywhere as it is a major schedule change.
             max_displacement = 6 * 2  # Two hours
             abs_diff_var = self.model.new_int_var(
-                0, max(talk_slot_max[talk_id], old_slot), f"talk_slot_abs_diff_{talk_id}_{old_slot}"
+                0, max(talk_slot_max[talk.id], talk.start), f"talk_slot_abs_diff_{talk.id}_{talk.start}"
             )
-            self.model.add_max_equality(abs_diff_var, [start - old_slot, old_slot - start])
-            diff_var = self.model.new_int_var(0, max_displacement, f"talk_slot_diff_{talk_id}_{old_slot}")
+            self.model.add_max_equality(abs_diff_var, [start - talk.start, talk.start - start])
+            diff_var = self.model.new_int_var(0, max_displacement, f"talk_slot_diff_{talk.id}_{talk.start}")
             self.model.add_min_equality(diff_var, [abs_diff_var, max_displacement])
             obj_vars.append(diff_var)
-            obj_scores.append(-(duration + 10))
+            obj_scores.append(-(talk.duration + 10))
 
             # Attempt to keep talks in the same venue. We prefer to keep talks
             # in the same timeslot over the same venue, so note that the score
             # is artificially increased by +10 above otherwise they would score
             # equally.
-            if (talk_id, old_venue) in self.talk_venue_active_vars:
-                obj_vars.append(self.talk_venue_active_vars[(talk_id, old_venue)])
-                obj_scores.append(duration)
+            if (talk.id, talk.venue) in self.talk_venue_active_vars:
+                obj_vars.append(self.talk_venue_active_vars[(talk.id, talk.venue)])
+                obj_scores.append(talk.duration)
 
         if obj_vars:
             self.model.maximize(cp_model.LinearExpr.weighted_sum(obj_vars, obj_scores))
 
-        return self.model
-
-    def schedule_talks(self, talks: Iterable[Talk], old_talks=None) -> list[tuple[Slot, TalkID, VenueID]]:
-        if old_talks is None:
-            old_talks = []
-        talks = list(talks)
+    def solve(self, debug: bool = False) -> SchedulingSolution:
         t0 = time.time()
 
         self.log.info("Generating schedule problem...")
 
-        venues = {v for talk in talks for v in talk.venues}
-        self.get_problem(venues, talks, old_talks)
+        talks = [SlottedTalk(talk, self.problem) for talk in self.problem.talks]
+
+        self.generate_problem(self.problem.venues, talks)
 
         self.log.info(
-            "Problem generated (%s variables) in %.2f seconds, attempting to solve...",
+            "Problem generated (%s variables) in %.3f seconds, attempting to solve...",
             len(self.model.proto.variables),
             time.time() - t0,
         )
@@ -233,8 +226,8 @@ class SlotMachine:
         self._solver = cp_model.CpSolver()
         self._solver.parameters.num_search_workers = 8
         self._solver.parameters.max_time_in_seconds = 30.0
-        self._solver.parameters.log_search_progress = True
-        self._solver.parameters.log_to_stdout = True
+        self._solver.parameters.log_search_progress = debug
+        self._solver.parameters.log_to_stdout = debug
 
         log = self.log
 
@@ -266,99 +259,18 @@ class SlotMachine:
             time.time() - t0,
         )
 
-        result = []
         for talk in talks:
             if talk.id not in self.talk_slot_vars:
                 continue
             start_val = self._solver.value(self.talk_slot_vars[talk.id])
             # This iterates over all possible venue placement vars to find the
             # one that was actually selected ("active")
-            for v in venues:
-                if (talk.id, v) in self.talk_venue_active_vars and bool(
-                    self._solver.value(self.talk_venue_active_vars[(talk.id, v)])
+            for venue in self.problem.venues:
+                if (talk.id, venue) in self.talk_venue_active_vars and bool(
+                    self._solver.value(self.talk_venue_active_vars[(talk.id, venue)])
                 ):
-                    result.append((start_val, talk.id, v))
+                    talk.start = start_val
+                    talk.venue = venue
                     break
 
-        return result
-
-    @classmethod
-    def num_slots(cls, start_time, end_time):
-        return int((end_time - start_time).total_seconds() / 60 / 10)
-
-    @classmethod
-    def calculate_slots(cls, event_start, range_start, range_end, spacing_slots=1):
-        slot_start = int((range_start - event_start).total_seconds() / 60 / 10)
-        # We add the number of slots that must be between events to the end to
-        # allow events to finish in the last period of the schedule
-        return (
-            slot_start,
-            slot_start + SlotMachine.num_slots(range_start, range_end) + spacing_slots - 1,
-        )
-
-    def calc_time(self, event_start: datetime, slots: int) -> datetime:
-        return event_start + relativedelta.relativedelta(minutes=slots * 10)
-
-    def calc_slot(self, event_start: datetime, time: datetime) -> Slot:
-        return int((time - event_start).total_seconds() / 60 / 10)
-
-    def schedule(self, schedule: dict, spacing_slots_default: int = 1) -> list[dict]:
-        talks = []
-        talk_data = {}
-        old_slots = []
-
-        event_start = min(parser.parse(r["start"]) for event in schedule for r in event["time_ranges"])
-
-        for event in schedule:
-            talk_data[event["id"]] = event
-            spacing_slots = event.get("spacing_slots", spacing_slots_default)
-            slot_intervals: list[tuple[Slot, Slot]] = []
-            preferred_intervals: list[tuple[Slot, Slot]] = []
-
-            for trange in event["time_ranges"]:
-                window = SlotMachine.calculate_slots(
-                    event_start,
-                    parser.parse(trange["start"]),
-                    parser.parse(trange["end"]),
-                    spacing_slots,
-                )
-                slot_intervals.append(window)
-
-            for trange in event.get("preferred_time_ranges", []):
-                window = SlotMachine.calculate_slots(
-                    event_start,
-                    parser.parse(trange["start"]),
-                    parser.parse(trange["end"]),
-                    spacing_slots,
-                )
-                preferred_intervals.append(window)
-
-            talks.append(
-                Talk(
-                    id=event["id"],
-                    venues=event["valid_venues"],
-                    speakers=event["speakers"],
-                    # We add the number of spacing slots that must be between
-                    # events to the duration
-                    duration=int(event["duration"] / 10) + spacing_slots,
-                    slot_intervals=slot_intervals,
-                    preferred_venues=event.get("preferred_venues", []),
-                    preferred_intervals=preferred_intervals,
-                )
-            )
-
-            if "time" in event and "venue" in event:
-                old_slots.append(
-                    (
-                        self.calc_slot(event_start, parser.parse(event["time"])),
-                        event["id"],
-                        event["venue"],
-                    )
-                )
-
-        solved = self.schedule_talks(talks, old_talks=old_slots)
-        for slot_id, talk_id, venue_id in solved:
-            talk_data[talk_id]["time"] = str(self.calc_time(event_start, slot_id))
-            talk_data[talk_id]["venue"] = venue_id
-
-        return list(talk_data.values())
+        return SchedulingSolution(talks=[talk.to_talk(self.problem) for talk in talks])

--- a/src/slotmachine/slots.py
+++ b/src/slotmachine/slots.py
@@ -1,0 +1,87 @@
+"""Internal data model which represents time in terms of slots."""
+
+from datetime import datetime
+
+from dateutil import relativedelta
+
+from .data import SchedulingProblem, SpeakerID, Talk, TalkID, VenueID
+
+type Slot = int
+type SlotInterval = tuple[Slot, Slot]
+
+
+def calc_slot(range_start: datetime, range_end: datetime, slot_duration: int) -> Slot:
+    """Calculate the number of slots between two times."""
+    return int((range_end - range_start).total_seconds() / 60 / slot_duration)
+
+
+def calculate_slots(event_start, range_start, range_end, slot_duration: int, spacing_slots=1) -> SlotInterval:
+    slot_start = calc_slot(event_start, range_start, slot_duration)
+    # We add the number of slots that must be between events to the end to
+    # allow events to finish in the last period of the schedule
+    return (
+        slot_start,
+        slot_start + calc_slot(range_start, range_end, slot_duration) + spacing_slots - 1,
+    )
+
+
+def calc_time(event_start: datetime, slots: int, slot_duration: int) -> datetime:
+    return event_start + relativedelta.relativedelta(minutes=slots * slot_duration)
+
+
+class SlottedTalk:
+    """A mirror of the Talk class with time measured in slots.
+
+    Data is copied from the Talk object here because mypy doesn't have a good way of type-checking proxy objects.
+    """
+
+    id: TalkID
+    #: Slotted duration, including changeover
+    duration: Slot
+    speakers: set[SpeakerID]
+
+    allowed_venues: set[VenueID]
+    preferred_venues: set[VenueID]
+
+    allowed_intervals: list[SlotInterval]
+    preferred_intervals: list[SlotInterval]
+
+    start: Slot | None
+    venue: VenueID | None
+
+    talk: Talk
+
+    def __init__(self, talk: Talk, problem: SchedulingProblem) -> None:
+        self.talk = talk
+        self.id = talk.id
+
+        self.duration = (talk.duration + talk.minutes_after) // problem.slot_duration
+
+        self.speakers = talk.speakers
+        self.allowed_venues = talk.allowed_venues
+        self.preferred_venues = talk.preferred_venues
+
+        changeover_after = talk.minutes_after // problem.slot_duration
+        self.allowed_intervals = [
+            calculate_slots(problem.start_time, *range, problem.slot_duration, spacing_slots=changeover_after)
+            for range in talk.allowed_times
+        ]
+        self.preferred_intervals = [
+            calculate_slots(problem.start_time, *range, problem.slot_duration, spacing_slots=changeover_after)
+            for range in talk.preferred_times
+        ]
+
+        if talk.start_time:
+            self.start = calc_slot(problem.start_time, talk.start_time, problem.slot_duration)
+        else:
+            self.start = None
+
+        self.venue = talk.venue
+
+    def to_talk(self, problem: SchedulingProblem) -> Talk:
+        if self.start is None:
+            raise ValueError("Attempting to convert talk without start slot")
+        talk = self.talk
+        talk.start_time = calc_time(problem.start_time, self.start, problem.slot_duration)
+        talk.venue = self.venue
+        return talk

--- a/src/slotmachine/slots.py
+++ b/src/slotmachine/slots.py
@@ -1,5 +1,6 @@
 """Internal data model which represents time in terms of slots."""
 
+import dataclasses
 from datetime import datetime
 
 from dateutil import relativedelta
@@ -81,7 +82,8 @@ class SlottedTalk:
     def to_talk(self, problem: SchedulingProblem) -> Talk:
         if self.start is None:
             raise ValueError("Attempting to convert talk without start slot")
-        talk = self.talk
-        talk.start_time = calc_time(problem.start_time, self.start, problem.slot_duration)
-        talk.venue = self.venue
-        return talk
+        return dataclasses.replace(
+            self.talk,
+            start_time=calc_time(problem.start_time, self.start, problem.slot_duration),
+            venue=self.venue,
+        )

--- a/tests/test_slotmachine.py
+++ b/tests/test_slotmachine.py
@@ -1,10 +1,29 @@
+from datetime import timedelta
 from itertools import permutations
 
 import pytest
 from dateutil.parser import parse as ts
+from hypothesis import assume, given
+from hypothesis import strategies as st
 
 from slotmachine import SlotMachine, Talk, Unsatisfiable
 from slotmachine.data import SchedulingProblem, SchedulingSolution, TimeRange
+
+SLOT_DURATION = 10
+
+
+@st.composite
+def durations(draw, min_duration=10, max_duration=120):
+    """Hypothesis strategy to generate a talk duration which is a multiple of the slot duration."""
+    return (
+        draw(st.integers(min_value=min_duration // SLOT_DURATION, max_value=max_duration // SLOT_DURATION))
+        * SLOT_DURATION
+    )
+
+
+def total_duration(talks: list[Talk]) -> timedelta:
+    """Return the total duration of a list of talks, including changeover time."""
+    return timedelta(minutes=sum(talk.duration + talk.minutes_after for talk in talks))
 
 
 def time_overlaps(range1: TimeRange, range2: TimeRange) -> bool:
@@ -15,7 +34,8 @@ def time_overlaps(range1: TimeRange, range2: TimeRange) -> bool:
 
 
 def schedule_assert_solvable(talks: list[Talk]) -> SchedulingSolution:
-    sm = SlotMachine(SchedulingProblem(talks=talks, slot_duration=10))
+    """Run the scheduler on a list of talks, asserting that it's solveable and the result looks valid."""
+    sm = SlotMachine(SchedulingProblem(talks=talks, slot_duration=SLOT_DURATION))
     solution = sm.solve()
 
     # All talks must be represented
@@ -59,31 +79,25 @@ def schedule_assert_fail(talks: list[Talk]):
         sm.solve()
 
 
-def test_simple():
-    allowed_times = [(ts("2016-08-06 13:00"), ts("2016-08-06 15:00"))]
+@given(st.lists(durations(), min_size=1), durations())
+def test_simple(durations, minutes_after):
+    allowed_times = (ts("2016-08-06 13:00"), ts("2016-08-06 15:00"))
+
     talk_defs = [
         Talk(
-            id=1,
-            duration=30,
+            id=i,
+            duration=durations[i],
             allowed_venues={101},
             speakers={1},
-            allowed_times=allowed_times,
-        ),
-        Talk(
-            id=2,
-            duration=30,
-            allowed_venues={101},
-            speakers={2},
-            allowed_times=allowed_times,
-        ),
-        Talk(
-            id=3,
-            duration=30,
-            allowed_venues={101},
-            speakers={3},
-            allowed_times=allowed_times,
-        ),
+            allowed_times=[allowed_times],
+            minutes_after=minutes_after,
+        )
+        for i in range(0, len(durations))
     ]
+
+    assume(
+        total_duration(talk_defs) <= (allowed_times[1] - allowed_times[0]) + timedelta(minutes=minutes_after)
+    )
 
     solved = schedule_assert_solvable(talk_defs)
 
@@ -92,14 +106,24 @@ def test_simple():
     assert solved == solved_second
 
 
-def test_too_many_talks():
-    """This should just exceed the number of available slots (12 + 1)"""
-    allowed_times = [(ts("2016-08-06 13:00"), ts("2016-08-06 15:00"))]
+@given(st.lists(durations(), min_size=1), durations())
+def test_too_many_talks(durations, minutes_after):
+    allowed_times = (ts("2016-08-06 13:00"), ts("2016-08-06 15:00"))
+
     talk_defs = [
-        Talk(id=1, duration=40, allowed_venues={101}, speakers={1}, allowed_times=allowed_times),
-        Talk(id=2, duration=40, allowed_venues={101}, speakers={2}, allowed_times=allowed_times),
-        Talk(id=3, duration=30, allowed_venues={101}, speakers={3}, allowed_times=allowed_times),
+        Talk(
+            id=i,
+            duration=durations[i],
+            allowed_venues={101},
+            speakers={1},
+            allowed_times=[allowed_times],
+            minutes_after=minutes_after,
+        )
+        for i in range(0, len(durations))
     ]
+    assume(
+        total_duration(talk_defs) > (allowed_times[1] - allowed_times[0]) + timedelta(minutes=minutes_after)
+    )
 
     schedule_assert_fail(talk_defs)
 

--- a/tests/test_slotmachine.py
+++ b/tests/test_slotmachine.py
@@ -1,227 +1,291 @@
-import unittest
-from collections import defaultdict
+from itertools import permutations
 
-from dateutil import parser
+import pytest
+from dateutil.parser import parse as ts
 
 from slotmachine import SlotMachine, Talk, Unsatisfiable
+from slotmachine.data import SchedulingProblem, SchedulingSolution, TimeRange
 
 
-def unzip(iter):
-    return zip(*iter, strict=True)
+def time_overlaps(range1: TimeRange, range2: TimeRange) -> bool:
+    latest_start = max(range1[0], range2[0])
+    earliest_end = min(range1[1], range2[1])
+    delta = (earliest_end - latest_start).total_seconds()
+    return delta > 0
 
 
-def _slots_in_intervals(slot, intervals) -> bool:
-    return any(lo <= slot <= hi for lo, hi in intervals)
+def schedule_assert_solvable(talks: list[Talk]) -> SchedulingSolution:
+    sm = SlotMachine(SchedulingProblem(talks=talks, slot_duration=10))
+    solution = sm.solve()
+
+    # All talks must be represented
+    assert set(talk.id for talk in talks) == set(talk.id for talk in solution.talks)
+
+    # All time/venue tuples must be different
+    slot_venues = [(talk.venue, talk.start_time) for talk in solution.talks]
+    assert sorted(set(slot_venues)) == sorted(slot_venues)
+
+    for talk in solution.talks:
+        # Venue must be allowed
+        assert talk.venue in talk.allowed_venues
+
+        # Talk must be assigned a start time
+        assert talk.start_time
+        assert any(start <= talk.start_time < end for (start, end) in talk.allowed_times)
+
+        # End time should be calculated correctly
+        assert talk.end_time
+        assert talk.end_time > talk.start_time
+        # Talk should end in allowed times
+        assert any(start < talk.end_time <= end for (start, end) in talk.allowed_times)
+
+    # Talks must not overlap
+    for a, b in permutations(solution.talks, 2):
+        assert a.start_time and a.end_time
+        assert b.start_time and b.end_time
+        if a.venue == b.venue:
+            assert not time_overlaps(
+                (a.start_time, a.end_time),
+                (b.start_time, b.end_time),
+            )
+
+    return solution
 
 
-class UtilTestCase(unittest.TestCase):
-    def test_calculate_slots(self):
-        event_start = parser.parse("2016-08-05 13:00")
-        slots_minimal = SlotMachine.calculate_slots(
-            event_start,
-            parser.parse("2016-08-05 13:00"),
-            parser.parse("2016-08-05 14:00"),
-        )
-        # the final slot is because all talks are made one slot longer for changeover
-        assert slots_minimal == (0, 6)
-        slots_sat_13_16 = SlotMachine.calculate_slots(
-            event_start,
-            parser.parse("2016-08-06 13:00"),
-            parser.parse("2016-08-06 16:00"),
-        )
-        assert slots_sat_13_16 == (144, 144 + 18)
+def schedule_assert_fail(talks: list[Talk]):
+    sm = SlotMachine(SchedulingProblem(talks=talks, slot_duration=10))
+
+    with pytest.raises(Unsatisfiable):
+        sm.solve()
 
 
-class ScheduleTalksTestCase(unittest.TestCase):
-    def schedule_and_basic_asserts(self, talk_defs, old_talks=None):
-        if old_talks is None:
-            old_talks = []
+def test_simple():
+    allowed_times = [(ts("2016-08-06 13:00"), ts("2016-08-06 15:00"))]
+    talk_defs = [
+        Talk(
+            id=1,
+            duration=30,
+            allowed_venues={101},
+            speakers={1},
+            allowed_times=allowed_times,
+        ),
+        Talk(
+            id=2,
+            duration=30,
+            allowed_venues={101},
+            speakers={2},
+            allowed_times=allowed_times,
+        ),
+        Talk(
+            id=3,
+            duration=30,
+            allowed_venues={101},
+            speakers={3},
+            allowed_times=allowed_times,
+        ),
+    ]
 
-        talk_ids = [t.id for t in talk_defs]
-        talk_defs_by_id = {t.id: t for t in talk_defs}
+    solved = schedule_assert_solvable(talk_defs)
 
-        sm = SlotMachine()
+    # Solution should be stable
+    solved_second = schedule_assert_solvable(solved.talks)
+    assert solved == solved_second
 
-        solved = sm.schedule_talks(talk_defs, old_talks=old_talks)
-        slots, talks, venues = unzip(solved)
 
-        # All talks must be represented
-        self.assertEqual(sorted(talks), sorted(talk_ids))
-        # All slots/venue tuples must be different
-        slot_venues = list(zip(slots, venues, strict=False))
-        self.assertEqual(sorted(set(slot_venues)), sorted(slot_venues))
+def test_too_many_talks():
+    """This should just exceed the number of available slots (12 + 1)"""
+    allowed_times = [(ts("2016-08-06 13:00"), ts("2016-08-06 15:00"))]
+    talk_defs = [
+        Talk(id=1, duration=40, allowed_venues={101}, speakers={1}, allowed_times=allowed_times),
+        Talk(id=2, duration=40, allowed_venues={101}, speakers={2}, allowed_times=allowed_times),
+        Talk(id=3, duration=30, allowed_venues={101}, speakers={3}, allowed_times=allowed_times),
+    ]
 
-        used_slots = defaultdict(set)
-        for slot, talk, venue in solved:
-            talk_def = talk_defs_by_id[talk]
+    schedule_assert_fail(talk_defs)
 
-            self.assertIn(venue, talk_def.venues)
-            self.assertTrue(_slots_in_intervals(slot, talk_def.slot_intervals))
 
-            for i in range(talk_def.duration):
-                self.assertNotIn(slot + i, used_slots[venue])
-                used_slots[venue].add(slot + i)
+def test_invalid_allowed_times():
+    """Talk with a duration longer than any of its allowed_times slots"""
+    allowed_times = [
+        (ts("2016-08-06 13:00"), ts("2016-08-06 14:00")),
+        (ts("2016-08-06 16:00"), ts("2016-08-06 17:00")),
+    ]
+    talk_defs = [
+        Talk(id=1, duration=70, allowed_venues={101}, speakers={1}, allowed_times=allowed_times),
+    ]
 
-        return solved
+    schedule_assert_fail(talk_defs)
 
-    def schedule_and_assert_fails(self, talk_defs, old_talks=None):
-        if old_talks is None:
-            old_talks = []
 
-        sm = SlotMachine()
+def test_two_venues():
+    # talk 3 should end up in venue 102
+    allowed_times = [(ts("2016-08-06 13:00"), ts("2016-08-06 14:00"))]
+    talk_defs = [
+        Talk(id=1, duration=50, allowed_venues={101}, speakers={1}, allowed_times=allowed_times),
+        Talk(id=2, duration=20, allowed_venues={102}, speakers={2}, allowed_times=allowed_times),
+        Talk(id=3, duration=20, allowed_venues={101, 102}, speakers={3}, allowed_times=allowed_times),
+    ]
 
-        with self.assertRaises(Unsatisfiable):
-            sm.schedule_talks(talk_defs, old_talks=old_talks)
+    solved = schedule_assert_solvable(talk_defs)
 
-    def test_simple(self):
-        avail_slots = SlotMachine.calculate_slots(
-            parser.parse("2016-08-06 13:00"),
-            parser.parse("2016-08-06 13:00"),
-            parser.parse("2016-08-06 15:00"),
-        )
-        talk_defs = [
-            Talk(id=1, duration=3 + 1, venues=[101], speakers=["Speaker 1"], slot_intervals=[avail_slots]),
-            Talk(id=2, duration=3 + 1, venues=[101], speakers=["Speaker 2"], slot_intervals=[avail_slots]),
-            Talk(id=3, duration=3 + 1, venues=[101], speakers=["Speaker 3"], slot_intervals=[avail_slots]),
-        ]
+    for talk in solved.talks:
+        if talk.id == 3:
+            assert talk.venue == 102
 
-        solved = self.schedule_and_basic_asserts(talk_defs)
 
-        # Solution should be stable
-        solved_second = self.schedule_and_basic_asserts(talk_defs, old_talks=solved)
-        self.assertEqual(solved, solved_second)
+def test_venue_too_full():
+    # Talks 1 and 3 won't fit into 101 together, and 3 and 4 won't fit in 102 together
+    allowed_times = [(ts("2016-08-06 13:00"), ts("2016-08-06 15:00"))]
+    talk_defs = [
+        Talk(id=1, duration=70, allowed_venues={101}, speakers={1}, allowed_times=allowed_times),
+        Talk(id=2, duration=40, allowed_venues={101, 102}, speakers={2}, allowed_times=allowed_times),
+        Talk(id=3, duration=50, allowed_venues={101, 102}, speakers={3}, allowed_times=allowed_times),
+        Talk(id=4, duration=70, allowed_venues={102}, speakers={4}, allowed_times=allowed_times),
+    ]
 
-    def test_too_many_talks(self):
-        # This should just exceed the number of available slots (12 + 1)
-        avail_slots = SlotMachine.calculate_slots(
-            parser.parse("2016-08-06 13:00"),
-            parser.parse("2016-08-06 13:00"),
-            parser.parse("2016-08-06 15:00"),
-        )
-        talk_defs = [
-            Talk(id=1, duration=4 + 1, venues=[101], speakers=["Speaker 1"], slot_intervals=[avail_slots]),
-            Talk(id=2, duration=4 + 1, venues=[101], speakers=["Speaker 2"], slot_intervals=[avail_slots]),
-            Talk(id=3, duration=3 + 1, venues=[101], speakers=["Speaker 3"], slot_intervals=[avail_slots]),
-        ]
+    schedule_assert_fail(talk_defs)
 
-        self.schedule_and_assert_fails(talk_defs)
 
-    def test_two_venues(self):
-        # talk 3 should end up in venue 102
-        avail_slots = SlotMachine.calculate_slots(
-            parser.parse("2016-08-06 13:00"),
-            parser.parse("2016-08-06 13:00"),
-            parser.parse("2016-08-06 14:00"),
-        )
-        talk_defs = [
-            Talk(id=1, duration=5 + 1, venues=[101], speakers=["Speaker 1"], slot_intervals=[avail_slots]),
-            Talk(id=2, duration=2 + 1, venues=[102], speakers=["Speaker 2"], slot_intervals=[avail_slots]),
-            Talk(
-                id=3, duration=2 + 1, venues=[101, 102], speakers=["Speaker 3"], slot_intervals=[avail_slots]
-            ),
-        ]
+def test_venue_clash():
+    # Talks 2 and 3 must move to accommodate talk 4
+    allowed_times = [(ts("2016-08-06 13:00"), ts("2016-08-06 15:00"))]
+    talk_defs = [
+        Talk(
+            id=1,
+            duration=70,
+            allowed_venues={101},
+            speakers={1},
+            allowed_times=allowed_times,
+            start_time=ts("2016-08-06 13:00"),
+            venue=101,
+        ),
+        Talk(
+            id=2,
+            duration=40,
+            allowed_venues={101, 102},
+            speakers={2},
+            allowed_times=allowed_times,
+            start_time=ts("2016-08-06 13:20"),
+            venue=102,
+        ),
+        Talk(
+            id=3,
+            duration=40,
+            allowed_venues={101, 102},
+            speakers={3},
+            allowed_times=allowed_times,
+            start_time=ts("2016-08-06 14:10"),
+            venue=102,
+        ),
+        Talk(id=4, duration=70, allowed_venues={102}, speakers={4}, allowed_times=allowed_times),
+    ]
 
-        solved = self.schedule_and_basic_asserts(talk_defs)
+    solved = schedule_assert_solvable(talk_defs)
 
-        talk_venues = dict([(t, v) for s, t, v in solved])
-        self.assertEqual(talk_venues[3], 102)
+    for talk in solved.talks:
+        if talk.id == 1:
+            # Talk 1 shouldn't move
+            assert talk.venue == 101
+            assert talk.start_time == ts("2016-08-06 13:00")
 
-    def test_venue_too_full(self):
-        # Talks 1 and 3 won't fit into 101 together, and 3 and 4 won't fit in 102 together
-        avail_slots = SlotMachine.calculate_slots(
-            parser.parse("2016-08-06 13:00"),
-            parser.parse("2016-08-06 13:00"),
-            parser.parse("2016-08-06 15:00"),
-        )
-        talk_defs = [
-            Talk(id=1, duration=7 + 1, venues=[101], speakers=["Speaker 1"], slot_intervals=[avail_slots]),
-            Talk(
-                id=2, duration=4 + 1, venues=[101, 102], speakers=["Speaker 2"], slot_intervals=[avail_slots]
-            ),
-            Talk(
-                id=3, duration=5 + 1, venues=[101, 102], speakers=["Speaker 3"], slot_intervals=[avail_slots]
-            ),
-            Talk(id=4, duration=7 + 1, venues=[102], speakers=["Speaker 4"], slot_intervals=[avail_slots]),
-        ]
 
-        self.schedule_and_assert_fails(talk_defs)
+def test_speaker_clash():
+    # Talk 4 is by Speaker 1
+    # Either talk 2 or 3 will have to move
+    allowed_times = [(ts("2016-08-06 13:00"), ts("2016-08-06 15:00"))]
+    talk_defs = [
+        Talk(
+            id=1,
+            duration=70,
+            allowed_venues={101},
+            speakers={1},
+            allowed_times=allowed_times,
+            start_time=ts("2016-08-06 13:00"),
+            venue=101,
+        ),
+        Talk(
+            id=2,
+            duration=70,
+            allowed_venues={102},
+            speakers={2},
+            allowed_times=allowed_times,
+            start_time=ts("2016-08-06 13:50"),
+            venue=102,
+        ),
+        Talk(
+            id=3,
+            duration=40,
+            allowed_venues={101, 102},
+            speakers={3},
+            allowed_times=allowed_times,
+            start_time=ts("2016-08-06 14:20"),
+            venue=101,
+        ),
+        Talk(id=4, duration=40, allowed_venues={101, 102}, speakers={1}, allowed_times=allowed_times),
+    ]
 
-    def test_venue_clash(self):
-        # Talks 2 and 3 must move to accommodate talk 4
-        avail_slots = SlotMachine.calculate_slots(
-            parser.parse("2016-08-06 13:00"),
-            parser.parse("2016-08-06 13:00"),
-            parser.parse("2016-08-06 15:00"),
-        )
-        talk_defs = [
-            Talk(id=1, duration=7 + 1, venues=[101], speakers=["Speaker 1"], slot_intervals=[avail_slots]),
-            Talk(
-                id=2, duration=4 + 1, venues=[101, 102], speakers=["Speaker 2"], slot_intervals=[avail_slots]
-            ),
-            Talk(
-                id=3, duration=4 + 1, venues=[101, 102], speakers=["Speaker 3"], slot_intervals=[avail_slots]
-            ),
-            Talk(id=4, duration=7 + 1, venues=[102], speakers=["Speaker 4"], slot_intervals=[avail_slots]),
-        ]
+    solved = schedule_assert_solvable(talk_defs)
 
-        old_talks = [(0, 1, 101), (2, 2, 102), (7, 3, 102)]
-        solved = self.schedule_and_basic_asserts(talk_defs, old_talks=old_talks)
+    for talk in solved.talks:
+        assert talk.start_time is not None
+        match talk.id:
+            case 1:
+                # There's no reason to move talk 1
+                assert talk.venue == 101
+                assert talk.start_time == ts("2016-08-06 13:00")
+            case 4:
+                # Talk 4 needs to be scheduled after talk 1 has finished
+                assert talk.venue in {101, 102}
+                assert talk.start_time > ts("2016-08-06 14:10")
 
-        # Talk 1 shouldn't move
-        self.assertIn((0, 1, 101), solved)
 
-    def test_speaker_clash(self):
-        # Talk 4 is by Speaker 1
-        avail_slots = SlotMachine.calculate_slots(
-            parser.parse("2016-08-06 13:00"),
-            parser.parse("2016-08-06 13:00"),
-            parser.parse("2016-08-06 15:00"),
-        )
-        talk_defs = [
-            Talk(id=1, duration=7 + 1, venues=[101], speakers=["Speaker 1"], slot_intervals=[avail_slots]),
-            Talk(id=2, duration=7 + 1, venues=[102], speakers=["Speaker 2"], slot_intervals=[avail_slots]),
-            Talk(
-                id=3, duration=4 + 1, venues=[101, 102], speakers=["Speaker 3"], slot_intervals=[avail_slots]
-            ),
-            Talk(
-                id=4, duration=4 + 1, venues=[101, 102], speakers=["Speaker 1"], slot_intervals=[avail_slots]
-            ),
-        ]
+def test_talk_clash():
+    # Talk 4 now has to precede talk 1. Talks 2 and 3 must remain in 102
+    allowed_times = [(ts("2016-08-06 13:00"), ts("2016-08-06 15:00"))]
+    talk_defs = [
+        Talk(
+            id=1,
+            duration=70,
+            allowed_venues={101},
+            speakers={1},
+            allowed_times=allowed_times,
+            start_time=ts("2016-08-06 13:00"),
+        ),
+        Talk(
+            id=2,
+            duration=50,
+            allowed_venues={101, 102},
+            speakers={2},
+            allowed_times=allowed_times,
+            start_time=ts("2016-08-06 13:00"),
+        ),
+        Talk(
+            id=3,
+            duration=50,
+            allowed_venues={101, 102},
+            speakers={3},
+            allowed_times=allowed_times,
+            start_time=ts("2016-08-06 14:20"),
+        ),
+        Talk(
+            id=4,
+            duration=20,
+            allowed_venues={101, 102},
+            speakers={4},
+            allowed_times=[(ts("2016-08-06 13:00"), ts("2016-08-06 13:20"))],
+            start_time=ts("2016-08-06 15:00"),
+        ),
+    ]
 
-        # Either talk 2 or 3 will have to move
-        old_talks = [(0, 1, 101), (5, 2, 102), (8, 3, 101)]
-        solved = self.schedule_and_basic_asserts(talk_defs, old_talks=old_talks)
+    solved = schedule_assert_solvable(talk_defs)
 
-        slots, talks, _venues = unzip(solved)
-        talks_slots = dict(zip(talks, slots, strict=False))
+    solved_talks = {talk.id: talk for talk in solved.talks}
+    assert (
+        solved_talks[4].start_time
+        and solved_talks[1].start_time
+        and solved_talks[4].start_time < solved_talks[1].start_time
+    )
 
-        # There's no reason to move talk 1, so the speaker's only available afterwards
-        self.assertTrue(talks_slots[4] >= 8)
-
-    def test_talk_clash(self):
-        # Talk 4 now has to precede talk 1. Talks 2 and 3 must remain in 102
-        avail_slots = SlotMachine.calculate_slots(
-            parser.parse("2016-08-06 13:00"),
-            parser.parse("2016-08-06 13:00"),
-            parser.parse("2016-08-06 15:00"),
-        )
-        talk_defs = [
-            Talk(id=1, duration=7 + 1, venues=[101], speakers=["Speaker 1"], slot_intervals=[avail_slots]),
-            Talk(
-                id=2, duration=5 + 1, venues=[101, 102], speakers=["Speaker 2"], slot_intervals=[avail_slots]
-            ),
-            Talk(
-                id=3, duration=5 + 1, venues=[101, 102], speakers=["Speaker 3"], slot_intervals=[avail_slots]
-            ),
-            Talk(id=4, duration=2 + 1, venues=[101, 102], speakers=["Speaker 4"], slot_intervals=[(0, 2)]),
-        ]
-
-        # Talk 4 was previously scheduled after talk 1
-        old_talks = [(0, 1, 101), (0, 2, 102), (6, 3, 102), (8, 4, 101)]
-        solved = self.schedule_and_basic_asserts(talk_defs, old_talks=old_talks)
-
-        slots, talks, _venues = unzip(solved)
-        talks_slots = dict(zip(talks, slots, strict=False))
-
-        # Talk 1 must now be in slot 3 or 4
-        self.assertIn(talks_slots[1], [3, 4])
+    for talk in solved.talks:
+        if talk.id in (2, 3):
+            assert talk.venue == 102

--- a/tests/test_slots.py
+++ b/tests/test_slots.py
@@ -1,0 +1,41 @@
+from dateutil.parser import parse as ts
+
+from slotmachine.data import SchedulingProblem, Talk
+from slotmachine.slots import SlottedTalk, calculate_slots
+
+
+def test_calculate_slots():
+    event_start = ts("2016-08-05 13:00")
+    slots_minimal = calculate_slots(event_start, ts("2016-08-05 13:00"), ts("2016-08-05 14:00"), 10)
+    # the final slot is because all talks are made one slot longer for changeover
+    assert slots_minimal == (0, 6)
+
+    slots_sat_13_16 = calculate_slots(event_start, ts("2016-08-06 13:00"), ts("2016-08-06 16:00"), 10)
+    assert slots_sat_13_16 == (144, 144 + 18)
+
+
+def test_slot_conversion():
+    talks = [
+        Talk(
+            id=1,
+            allowed_times=[(ts("2016-08-05 13:00"), ts("2016-08-05 14:00"))],
+            duration=60,
+            speakers={1},
+            allowed_venues={101},
+        ),
+        Talk(
+            id=2,
+            allowed_times=[(ts("2016-08-05 14:00"), ts("2016-08-05 15:00"))],
+            duration=60,
+            speakers={2},
+            allowed_venues={102},
+        ),
+    ]
+
+    problem = SchedulingProblem(talks=talks, slot_duration=10)
+
+    assert problem.start_time == ts("2016-08-05 13:00")
+
+    t = SlottedTalk(talks[1], problem)
+    assert t.allowed_intervals[0] == (6, 12)
+    assert t.duration == 7  # 60 minutes + changover

--- a/uv.lock
+++ b/uv.lock
@@ -32,6 +32,18 @@ wheels = [
 ]
 
 [[package]]
+name = "hypothesis"
+version = "6.152.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/dd/19d273652eb20dac15f32bbc484f2f6d51ccd8fe51fdb27da3f85f9017e8/hypothesis-6.152.7.tar.gz", hash = "sha256:741dedcede2ae0f32c32929a5992804b61f2b0400403b6a51a881a2b58482782", size = 468147, upload-time = "2026-05-13T04:19:34.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/1e/8222edaee03c37350eaa726213614e343a62f1e56396dd000ad9277bfa3d/hypothesis-6.152.7-py3-none-any.whl", hash = "sha256:c0b17dd428fcb6e962f60315f6f4a77816c72fbb281ce9ba73699dabead5ec82", size = 533802, upload-time = "2026-05-13T04:19:30.635Z" },
+]
+
+[[package]]
 name = "immutabledict"
 version = "4.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -400,6 +412,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "hypothesis" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-github-actions-annotate-failures" },
@@ -415,11 +428,21 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "hypothesis", specifier = ">=6.152.7" },
     { name = "mypy", specifier = ">=1.17.1" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-github-actions-annotate-failures", specifier = ">=0.3.0" },
     { name = "ruff", specifier = ">=0.12.10" },
     { name = "types-python-dateutil", specifier = ">=2.9.0.20250822" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This draws a clean boundary between the external interface, which operates in datetimes, and the solver, which operates in slots. It improves type checking and makes writing tests a lot more straightforward.

Fixes #7