### PR TITLE
Add infeasibility explanation

### DIFF
--- a/src/slotmachine/slotmachine.py
+++ b/src/slotmachine/slotmachine.py
@@ -8,7 +8,9 @@ from .slots import Slot, SlottedTalk
 
 
 class Unsatisfiable(Exception):
-    pass
+    def __init__(self, status: str, explanations: list[str]) -> None:
+        self.status = status
+        self.explanations = explanations
 
 
 class SlotMachine:
@@ -19,6 +21,23 @@ class SlotMachine:
         # Vars representing the selected talk slot and venue
         self.talk_slot_vars: dict[TalkID, cp_model.IntVar] = {}
         self.talk_venue_active_vars: dict[tuple[TalkID, VenueID], cp_model.IntVar] = {}
+
+        self.infeasibility_vars: dict[str, str] = {}
+
+    def infeasibility_var(self, description: str) -> cp_model.IntVar:
+        """An assumed-true boolean variable to help identify which constraint is causing the model to be unsatisfiable.
+
+        This variable is bound to a constraint using `only_enforce_if`, and is linked to a human-readable
+        string. If the model is infeasible, OR-Tools can tell us the minimal set of these boolean variables
+        it needs to switch off in order to make the model solveable.
+
+        The human-readable strings are returned in the `explanations` field of the `Unsatisfiable` exception.
+        """
+        var_name = f"_infeasibility_{id(description)}"
+        self.infeasibility_vars[var_name] = description
+        var = self.model.new_bool_var(var_name)
+        self.model.add_assumption(var)
+        return var
 
     def generate_problem(self, venues: set[VenueID], talks: list[SlottedTalk]) -> None:
         self.model = cp_model.CpModel()
@@ -95,12 +114,16 @@ class SlotMachine:
                 venue_intervals.setdefault(venue, []).append(optional_talk_venue_interval)
 
             # Exactly one venue must be chosen for a talk
-            self.model.add(cp_model.LinearExpr.sum(venue_active_vars) == 1)
+            self.model.add(cp_model.LinearExpr.sum(venue_active_vars) == 1).only_enforce_if(
+                self.infeasibility_var(f"Unable to assign venue for talk {talk.id}")
+            )
 
         # No two talks may overlap in the same venue
-        for intervals in venue_intervals.values():
+        for venue, intervals in venue_intervals.items():
             if intervals:
-                self.model.add_no_overlap(intervals)
+                self.model.add_no_overlap(intervals).only_enforce_if(
+                    self.infeasibility_var(f"Talks overlap in venue {venue}")
+                )
 
         # And a speaker cannot give multiple talks simultaneously
         talks_by_speaker: dict[SpeakerID, list[TalkID]] = {}
@@ -110,9 +133,11 @@ class SlotMachine:
                 for speaker in talk.speakers:
                     talks_by_speaker.setdefault(speaker, []).append(talk.id)
 
-        for conflicts in talks_by_speaker.values():
+        for speaker, conflicts in talks_by_speaker.items():
             if len(conflicts) > 1:
-                self.model.add_no_overlap([talk_intervals[talk_id] for talk_id in conflicts])
+                self.model.add_no_overlap([talk_intervals[talk_id] for talk_id in conflicts]).only_enforce_if(
+                    self.infeasibility_var(f"Conflict for speaker {speaker}")
+                )
 
         ## Optimisation objective generation
         #
@@ -249,7 +274,11 @@ class SlotMachine:
         status = self._solver.solve(self.model, callback)
 
         if status not in (cp_model.OPTIMAL, cp_model.FEASIBLE):
-            raise Unsatisfiable()
+            explanations = [
+                self.infeasibility_vars[self.model.get_bool_var_from_proto_index(i).name]
+                for i in self._solver.sufficient_assumptions_for_infeasibility()
+            ]
+            raise Unsatisfiable(self._solver.status_name(status), explanations)
 
         self.log.info(
             "Problem solved (%s, %d solutions) in %.2f seconds. Total runtime %.2f seconds.",

--- a/tests/test_slotmachine.py
+++ b/tests/test_slotmachine.py
@@ -92,8 +92,10 @@ def assert_solution_looks_reasonable(problem: SchedulingProblem, solution: Sched
 def schedule_assert_fail(talks: list[Talk]) -> None:
     sm = SlotMachine(SchedulingProblem(talks=talks, slot_duration=10))
 
-    with pytest.raises(Unsatisfiable):
+    with pytest.raises(Unsatisfiable) as excinfo:
         sm.solve()
+
+    assert excinfo.value.status == "INFEASIBLE"
 
 
 @given(st.lists(durations(), min_size=1), durations(), time_ranges())


### PR DESCRIPTION
This adds boolean switches to each constraint, with a human-readable explanation. If the model is unsovable, OR-Tools can calculate the minimum set of these switches which need to be disabled to cause the model to solve. The human-readable explanations for these are reported as part of the Unsatisfiable exception.

It remains to be seen how useful this is in practice, but it provides some reasonable-seeming results in the tests.

Credit to [this blog post](https://medium.com/@ZiaH919/optimization-with-python-infeasibility-explanation-for-integer-programming-with-or-tools-7372b64322d) for the explanation.

(fixes? maybe? #1)