### PR TITLE
Make adjacent intervals contiguous

### DIFF
--- a/src/slotmachine/data.py
+++ b/src/slotmachine/data.py
@@ -17,6 +17,16 @@ def parse_time_range(range: dict[str, str]) -> tuple[datetime, datetime]:
     return (parse_datetime(range["start"]), parse_datetime(range["end"]))
 
 
+def merge_contiguous_time_ranges(ranges: list[TimeRange]) -> list[TimeRange]:
+    merged: list[TimeRange] = []
+    for start, end in sorted(ranges):
+        if merged and start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        else:
+            merged.append((start, end))
+    return merged
+
+
 def time_range_to_dict(time_range: TimeRange) -> dict[str, str]:
     return {"start": time_range[0].isoformat(), "end": time_range[1].isoformat()}
 
@@ -81,10 +91,14 @@ class Talk:
                 f"Talk {self.id} minutes_after {self.minutes_after} is not a multiple of slot duration {slot_duration}"
             )
 
+        # We merge the time ranges here because often they are adjacent and a
+        # talk may be longer than either one. They are actually merged as
+        # intervals later before the solver gets them, but we need to do it
+        # here too or they may not validate.
         if all(
             end - start < timedelta(minutes=self.duration)
             for vt in self.venue_times
-            for start, end in vt.times
+            for start, end in merge_contiguous_time_ranges(vt.times)
         ):
             raise ValueError(f"Talk {self.id} has no allowed time ranges long enough to schedule into.")
 

--- a/src/slotmachine/slots.py
+++ b/src/slotmachine/slots.py
@@ -47,6 +47,21 @@ def calc_time(event_start: datetime, slots: int, slot_duration: int) -> datetime
     return event_start + relativedelta.relativedelta(minutes=slots * slot_duration)
 
 
+def merge_intervals(intervals: list[SlotInterval]) -> list[SlotInterval]:
+    """Merge overlapping and adjacent slot intervals into contiguous ones.
+
+    If we don't do this then talks will be unable to span across intervals.
+    """
+
+    merged: list[SlotInterval] = []
+    for start, end in sorted(intervals):
+        if merged and start <= merged[-1][1] + 1:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        else:
+            merged.append((start, end))
+    return merged
+
+
 class SlottedTalk:
     """A mirror of the Talk class with time measured in slots.
 
@@ -82,21 +97,25 @@ class SlottedTalk:
         self.venue_intervals = [
             SlottedVenueIntervals(
                 venue=vt.venue,
-                intervals=[
-                    calculate_slots(
-                        problem.start_time, *time_range, problem.slot_duration, spacing_slots=changeover_after
-                    )
-                    for time_range in vt.times
-                ],
+                intervals=merge_intervals(
+                    [
+                        calculate_slots(
+                            problem.start_time, *time_range, problem.slot_duration, spacing_slots=changeover_after
+                        )
+                        for time_range in vt.times
+                    ]
+                ),
             )
             for vt in talk.venue_times
         ]
-        self.preferred_intervals = [
-            calculate_slots(
-                problem.start_time, *time_range, problem.slot_duration, spacing_slots=changeover_after
-            )
-            for time_range in talk.preferred_times
-        ]
+        self.preferred_intervals = merge_intervals(
+            [
+                calculate_slots(
+                    problem.start_time, *time_range, problem.slot_duration, spacing_slots=changeover_after
+                )
+                for time_range in talk.preferred_times
+            ]
+        )
 
         if talk.start_time:
             self.start = calc_slot(problem.start_time, talk.start_time, problem.slot_duration)

--- a/tests/test_slots.py
+++ b/tests/test_slots.py
@@ -4,6 +4,30 @@ from slotmachine.data import SchedulingProblem, Talk, VenueTimes
 from slotmachine.slots import SlottedTalk, calculate_slots
 
 
+def test_talk_can_span_adjacent_slot_ranges():
+    # This talk is longer than either of the two time ranges passed, but
+    # they're adjacent so it should be able to span them because they're
+    # internally made contiguous once converted to slots
+    talk = Talk(
+        id=1,
+        venue_times=[
+            VenueTimes(
+                venue=101,
+                times=[
+                    (ts("2016-08-05 10:00"), ts("2016-08-05 12:00")),
+                    (ts("2016-08-05 12:00"), ts("2016-08-05 14:00")),
+                ],
+            )
+        ],
+        duration=240,
+        speakers={1},
+    )
+    problem = SchedulingProblem(talks=[talk], slot_duration=10)
+
+    t = SlottedTalk(talk, problem)
+    assert t.venue_intervals[0].intervals == [(0, 24)]
+
+
 def test_calculate_slots():
     event_start = ts("2016-08-05 13:00")
     slots_minimal = calculate_slots(event_start, ts("2016-08-05 13:00"), ts("2016-08-05 14:00"), 10)


### PR DESCRIPTION
If we don't do this then talks can't span across them. This wasn't a problem with the previous model because everything worked on slots, however switching to the native or-tools Interval type means we need to pre-merge these or the scheduler will be very sad.